### PR TITLE
Extract initial library from reference

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     //trick: for the same plugin versions in all sub-modules
     alias(libs.plugins.androidLibrary).apply(false)
     alias(libs.plugins.kotlinMultiplatform).apply(false)
+    alias(libs.plugins.kotlinSerialization).apply(false)
 }
 
 fun gradlePropertyOrEnvironmentVariable(name: String) = (project.findProperty(name) ?: System.getenv(name)) as? String

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,37 @@
 [versions]
-agp = "8.5.2"
 kotlin = "2.0.20"
 
+# Shared
+kotlinx-coroutines = "1.8.1"
+kotlinx-serialization = "1.7.1"
+krypt = "0.3.1" # For SecureRandom - https://github.com/chRyNaN/krypt
+ktor = "2.3.12"
+okio = "3.9.0" # For SHA-256 and Base64
+turbine = "1.1.0"
+
+# Android
+agp = "8.5.2"
+androidx-browser = "1.8.0" # For CustomTabs
+
+
 [libraries]
+# Shared
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx-serialization" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+krypt-csprng = { module = "com.chrynan.krypt:krypt-csprng", version.ref = "krypt" }
+ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
+ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
+okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
+turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine"}
+# Android
+androidx-browser = { module = "androidx.browser:browser", version.ref = "androidx-browser" }
 
 [plugins]
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/oauth-core/build.gradle.kts
+++ b/oauth-core/build.gradle.kts
@@ -9,6 +9,8 @@ plugins {
 }
 
 kotlin {
+    explicitApi()
+
     androidTarget {
         publishAllLibraryVariants()
     }

--- a/oauth-core/build.gradle.kts
+++ b/oauth-core/build.gradle.kts
@@ -2,6 +2,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.kotlinSerialization)
     alias(libs.plugins.androidLibrary)
     `maven-publish`
     signing
@@ -25,10 +26,29 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            //put your multiplatform dependencies here
+            implementation(libs.kotlinx.coroutines.core)
+
+            implementation(libs.kotlinx.serialization.core)
+            implementation(libs.kotlinx.serialization.json)
+
+            implementation(libs.krypt.csprng)
+
+            implementation(libs.ktor.client.core)
+            implementation(libs.ktor.client.content.negotiation)
+            implementation(libs.ktor.serialization.kotlinx.json)
+
+            implementation(libs.okio)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
+
+            implementation(libs.kotlinx.coroutines.test)
+            implementation(libs.ktor.client.mock)
+
+            implementation(libs.turbine)
+        }
+        androidMain.dependencies {
+            implementation(libs.androidx.browser)
         }
     }
 }

--- a/oauth-core/src/androidMain/kotlin/com/collectiveidea/oauth/AndroidPKCEFlow.kt
+++ b/oauth-core/src/androidMain/kotlin/com/collectiveidea/oauth/AndroidPKCEFlow.kt
@@ -1,0 +1,20 @@
+package com.collectiveidea.oauth
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.browser.customtabs.CustomTabsIntent
+
+class AndroidPKCEFlow(private val context: Context): PlatformPKCEFlow {
+    override fun startSignIn(signInUrl: String, redirectUrl: String, completionHandler: (String?, String?) -> Unit) {
+        // NOTE: Android is unable to directly invoke the completionHandler to process the
+        // callback URL when the external web browser transfers control back to the app.
+
+        val customTabsIntent = CustomTabsIntent.Builder().build()
+        // TRICKY: If `Context` is an Application, not an Activity, we must
+        // supply the `FLAG_ACTIVITY_NEW_TASK` here so that CustomTabs can
+        // launch the URL in a new activity without error.
+        customTabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        customTabsIntent.launchUrl(context, Uri.parse(signInUrl))
+    }
+}

--- a/oauth-core/src/androidMain/kotlin/com/collectiveidea/oauth/AndroidPKCEFlow.kt
+++ b/oauth-core/src/androidMain/kotlin/com/collectiveidea/oauth/AndroidPKCEFlow.kt
@@ -5,7 +5,7 @@ import android.content.Intent
 import android.net.Uri
 import androidx.browser.customtabs.CustomTabsIntent
 
-class AndroidPKCEFlow(private val context: Context): PlatformPKCEFlow {
+public class AndroidPKCEFlow(private val context: Context): PlatformPKCEFlow {
     override fun startSignIn(signInUrl: String, redirectUrl: String, completionHandler: (String?, String?) -> Unit) {
         // NOTE: Android is unable to directly invoke the completionHandler to process the
         // callback URL when the external web browser transfers control back to the app.

--- a/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/AuthorizationCodeRequest.kt
+++ b/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/AuthorizationCodeRequest.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class AuthorizationCodeRequest(
+public data class AuthorizationCodeRequest(
     @SerialName("client_id") val clientId: String,
     @SerialName("grant_type") val grantType: String = "authorization_code",
     @SerialName("code") val code: String,

--- a/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/AuthorizationCodeRequest.kt
+++ b/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/AuthorizationCodeRequest.kt
@@ -1,0 +1,13 @@
+package com.collectiveidea.oauth
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AuthorizationCodeRequest(
+    @SerialName("client_id") val clientId: String,
+    @SerialName("grant_type") val grantType: String = "authorization_code",
+    @SerialName("code") val code: String,
+    @SerialName("code_verifier") val verifier: String,
+    @SerialName("redirect_uri") val redirectUrl: String,
+)

--- a/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/HttpClientJsonOauthHelper.kt
+++ b/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/HttpClientJsonOauthHelper.kt
@@ -17,7 +17,7 @@ import io.ktor.serialization.kotlinx.json.json
  * @param baseUrl The base URL of the JSON OAuth service, everything before `/oauth/<verb>` in
  *  the URL, and with a trailing slash: e.g. `https://www.example.com/path/`
  */
-fun HttpClientConfig<*>.installJsonOAuth(baseUrl: String) {
+public fun HttpClientConfig<*>.installJsonOAuth(baseUrl: String) {
     expectSuccess = true
 
     defaultRequest {
@@ -50,6 +50,6 @@ fun HttpClientConfig<*>.installJsonOAuth(baseUrl: String) {
     }
 }
 
-fun ContentType.isJson() = match(ContentType.Application.Json)
+internal fun ContentType.isJson() = match(ContentType.Application.Json)
 
-fun HttpResponse.isJson() = contentType()?.isJson() == true
+internal fun HttpResponse.isJson() = contentType()?.isJson() == true

--- a/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/HttpClientJsonOauthHelper.kt
+++ b/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/HttpClientJsonOauthHelper.kt
@@ -1,0 +1,55 @@
+package com.collectiveidea.oauth
+
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.call.body
+import io.ktor.client.plugins.HttpResponseValidator
+import io.ktor.client.plugins.ResponseException
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.accept
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+
+/**
+ * @param baseUrl The base URL of the JSON OAuth service, everything before `/oauth/<verb>` in
+ *  the URL, and with a trailing slash: e.g. `https://www.example.com/path/`
+ */
+fun HttpClientConfig<*>.installJsonOAuth(baseUrl: String) {
+    expectSuccess = true
+
+    defaultRequest {
+        url(baseUrl)
+
+        accept(ContentType.Application.Json)
+        contentType(ContentType.Application.Json)
+    }
+
+    install(ContentNegotiation) {
+        json()
+    }
+
+    // Intercept exceptions to extract JSON message content before passing the exceptions along
+    HttpResponseValidator {
+        handleResponseExceptionWithRequest { exception, _ ->
+            if (exception !is ResponseException) {
+                // Should never happen, except maybe in comparison failures when running unit tests.
+                throw exception
+            }
+
+            val error: OAuthError = if (exception.response.isJson()) {
+                exception.response.body()
+            } else {
+                OAuthError("unknown", exception.response.bodyAsText())
+            }
+
+            throw OAuthException(error, exception)
+        }
+    }
+}
+
+fun ContentType.isJson() = match(ContentType.Application.Json)
+
+fun HttpResponse.isJson() = contentType()?.isJson() == true

--- a/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/OAuthError.kt
+++ b/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/OAuthError.kt
@@ -1,0 +1,10 @@
+package com.collectiveidea.oauth
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class OAuthError(
+    @SerialName("error") val code: String,
+    @SerialName("error_description") val description: String,
+)

--- a/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/OAuthError.kt
+++ b/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/OAuthError.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class OAuthError(
+public data class OAuthError(
     @SerialName("error") val code: String,
     @SerialName("error_description") val description: String,
 )

--- a/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/OAuthException.kt
+++ b/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/OAuthException.kt
@@ -2,7 +2,7 @@ package com.collectiveidea.oauth
 
 import io.ktor.client.plugins.ResponseException
 
-class OAuthException(
-    val error: OAuthError,
+public class OAuthException(
+    public val error: OAuthError,
     responseException: ResponseException,
 ) : RuntimeException(error.description, responseException)

--- a/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/OAuthException.kt
+++ b/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/OAuthException.kt
@@ -1,0 +1,8 @@
+package com.collectiveidea.oauth
+
+import io.ktor.client.plugins.ResponseException
+
+class OAuthException(
+    val error: OAuthError,
+    responseException: ResponseException,
+) : RuntimeException(error.description, responseException)

--- a/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/OAuthService.kt
+++ b/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/OAuthService.kt
@@ -1,0 +1,26 @@
+package com.collectiveidea.oauth
+
+import kotlin.coroutines.cancellation.CancellationException
+
+interface OAuthService {
+    val clientId: String
+
+    /**
+     * Exchanges the code parameter affixed to the PKCE `redirect_uri` for access/refresh tokens.
+     *
+     * @param code The code parameter extracted from the `redirect_uri`
+     * @param verifier The original verifier used to generate the `code_challenge` that was included
+     *   as a sign-in URL query parameter.
+     * @param redirectUrl The original `redirect_uri` that was included as a sign-in URL query parameter.
+     */
+    @Throws(OAuthException::class, CancellationException::class)
+    suspend fun exchangeAuthorizationCode(code: String, verifier: String, redirectUrl: String): TokenResponse
+
+    /**
+     * Meant to be called when an access_token is no longer value, to get new access/refresh tokens.
+     *
+     * @param refreshToken The refresh token of a previous [TokenResponse]
+     */
+    @Throws(OAuthException::class, CancellationException::class)
+    suspend fun refreshTokens(refreshToken: String): TokenResponse
+}

--- a/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/OAuthService.kt
+++ b/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/OAuthService.kt
@@ -2,8 +2,8 @@ package com.collectiveidea.oauth
 
 import kotlin.coroutines.cancellation.CancellationException
 
-interface OAuthService {
-    val clientId: String
+public interface OAuthService {
+    public val clientId: String
 
     /**
      * Exchanges the code parameter affixed to the PKCE `redirect_uri` for access/refresh tokens.
@@ -14,7 +14,7 @@ interface OAuthService {
      * @param redirectUrl The original `redirect_uri` that was included as a sign-in URL query parameter.
      */
     @Throws(OAuthException::class, CancellationException::class)
-    suspend fun exchangeAuthorizationCode(code: String, verifier: String, redirectUrl: String): TokenResponse
+    public suspend fun exchangeAuthorizationCode(code: String, verifier: String, redirectUrl: String): TokenResponse
 
     /**
      * Meant to be called when an access_token is no longer value, to get new access/refresh tokens.
@@ -22,5 +22,5 @@ interface OAuthService {
      * @param refreshToken The refresh token of a previous [TokenResponse]
      */
     @Throws(OAuthException::class, CancellationException::class)
-    suspend fun refreshTokens(refreshToken: String): TokenResponse
+    public suspend fun refreshTokens(refreshToken: String): TokenResponse
 }

--- a/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/OAuthServiceImpl.kt
+++ b/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/OAuthServiceImpl.kt
@@ -1,0 +1,54 @@
+package com.collectiveidea.oauth
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+
+/**
+ * @param httpClient A pre-configured JSON-OAuth-ready HttpClient. Use the
+ *   [com.collectiveidea.oauth.installJsonOAuth] helper for easy client creation, e.g.
+ *
+ *   val client = HttpClient(engine) {
+ *      installJsonOAuth(baseUrl)
+ *   }
+ *
+ *  @param oauthBaseUrl The base URL, with trailing slash, for OAuth requests, e.g. "https://www.example.com/path/"
+ *  @param redirectUrl The PKCE redirect URL that the server will redirect the user to on successful
+ *    auth. The redirect URL is used to transfer control from the external web view in the PKCE flow
+ *    back to the native application. On successful auth, the URL will have a "code" query parameter
+ *    appended that can be exchanged for access/refresh tokens via exchangeAuthorizationCode.
+ */
+class OAuthServiceImpl(
+    private val httpClient: HttpClient,
+    override val clientId: String,
+) : OAuthService {
+    override suspend fun exchangeAuthorizationCode(code: String, verifier: String, redirectUrl: String): TokenResponse {
+        val response: HttpResponse = httpClient.post("oauth/token") {
+            setBody(
+                AuthorizationCodeRequest(
+                    clientId = clientId,
+                    code = code,
+                    verifier = verifier,
+                    redirectUrl = redirectUrl,
+                ),
+            )
+        }
+
+        return response.body()
+    }
+
+    override suspend fun refreshTokens(refreshToken: String): TokenResponse {
+        val response: HttpResponse = httpClient.post("oauth/token") {
+            setBody(
+                RefreshTokensRequest(
+                    clientId = clientId,
+                    refreshToken = refreshToken,
+                ),
+            )
+        }
+
+        return response.body()
+    }
+}

--- a/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/OAuthServiceImpl.kt
+++ b/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/OAuthServiceImpl.kt
@@ -20,7 +20,7 @@ import io.ktor.client.statement.HttpResponse
  *    back to the native application. On successful auth, the URL will have a "code" query parameter
  *    appended that can be exchanged for access/refresh tokens via exchangeAuthorizationCode.
  */
-class OAuthServiceImpl(
+public class OAuthServiceImpl(
     private val httpClient: HttpClient,
     override val clientId: String,
 ) : OAuthService {

--- a/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/PKCEFlow.kt
+++ b/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/PKCEFlow.kt
@@ -1,0 +1,188 @@
+package com.collectiveidea.oauth
+
+import com.chrynan.krypt.csprng.SecureRandom
+import io.ktor.http.URLParserException
+import io.ktor.http.Url
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlin.random.Random
+
+/**
+ * Encapsulates the PKCE Flow.
+ *
+ * This class is typically a singleton, since only one PKCE Flow happens at a time.
+ *
+ * @param platformPKCEFlow The platform-native implementation that handles the external auth session.
+ * @param oauthService
+ * @param oauthBaseUrl The fully qualified URL up until the "oauth" in the path. That is, if the sign
+ *  in URL is "https://www.example.com/path/oauth/authorize", then this should be
+ *  "https://www.example.com/path/"
+ * @param redirectUrl The app-scheme URL and path that the external sign in process should use to transfer
+ * control back to the application after external authorization session finishes.
+ *  This must be the scheme that your app is registered to handle. A typical example is "exampleapp://auth"
+ * @param externalScope The scope to use to launch the network request that exchanges the challenge code
+ *  returned to the app (from the external authorization session) for the first set of access/refresh tokens.
+ * @param ioDispatcher The coroutine context to move the network request to, typically `Dispatchers.IO`
+ * @param random This should _always_ be `SecureRandom()`, but we allow constructor injection here in order
+ *  to control the randomization values generated under test.
+ */
+class PKCEFlow(
+    private val platformPKCEFlow: PlatformPKCEFlow,
+    private val oauthService: OAuthService,
+    val oauthBaseUrl: String,
+    val redirectUrl: String,
+    private val externalScope: CoroutineScope,
+    private val ioDispatcher: CoroutineDispatcher,
+    private val random: Random = SecureRandom(),
+) {
+    private val pkce by lazy { PKCEUtil(random) }
+
+    data class PKCEAuthState(
+        val state: State = State.NOT_STARTED,
+        val tokenResponse: TokenResponse? = null,
+        val errorMessage: String? = null,
+    ) {
+        enum class State {
+            NOT_STARTED,
+            WAITING_FOR_AUTHORIZATION_CODE,
+            EXCHANGING_AUTHORIZATION_CODE,
+            FINISHED,
+        }
+    }
+
+    private val _authState = MutableStateFlow(PKCEAuthState())
+    val authState = _authState.asStateFlow()
+
+    private var verifier: String? = null
+
+    /**
+     * Constructs the sign-in URL to open in an external web browser so that the user
+     * can complete the OAuth PKCE flow on the external website.
+     */
+    internal fun buildSignInUrl(): String {
+        // Re-generate the verifier on every request. Save the value, since we need it as
+        // part of the exchange flow.
+        verifier = pkce.generateCodeVerifier()
+
+        val method = PKCEUtil.CodeChallengeMethod.S256
+        val challenge = pkce.createCodeChallenge(verifier!!, method)
+
+        // Could attempt to use KTor internals here to build the URL, but it's non-obvious so
+        // we just roll our own since this is pretty simple.
+        val authParams = mapOf(
+            "client_id" to oauthService.clientId,
+            "redirect_uri" to urlEncodedRedirectUrl,
+            "response_type" to "code",
+            "scope" to "public+write", // Uses + here instead of space to URL-encode
+            "code_challenge" to challenge,
+            "code_challenge_method" to method.typeName,
+        ).map { (k, v) -> "$k=$v" }.joinToString("&")
+
+        return "${oauthBaseUrl}oauth/authorize?$authParams"
+    }
+
+    // Supply our own trivial helper to URL-encode the redirect URL, since it needs to
+    // be passed as a query param to the OAuth sign in URL.
+    private val urlEncodedRedirectUrl: String get() {
+        return redirectUrl.split("://").joinToString("%3A%2F%2F")
+    }
+
+    /**
+     * Main entry point for the PKCE Flow. Transfers control of the auth process to the platform,
+     * which opens the external browser to the appropriate sign in URL.
+     */
+    fun startSignIn() {
+        _authState.update {
+            PKCEAuthState(PKCEAuthState.State.WAITING_FOR_AUTHORIZATION_CODE)
+        }
+
+        val signInUrl = buildSignInUrl()
+        platformPKCEFlow.startSignIn(signInUrl, redirectUrl, ::continueSignInWithCallbackOrError)
+    }
+
+    /**
+     * The platform finishes the auth process and transfers control back to the application, which
+     * in turn needs to transfer control back here to process the callback URL to swap the
+     * authorization code for access/refresh tokens.
+     */
+    fun continueSignInWithCallbackOrError(
+        callbackUrl: String?,
+        errorMessage: String?,
+    ) {
+        if (errorMessage != null) {
+            _authState.update {
+                PKCEAuthState(
+                    PKCEAuthState.State.FINISHED,
+                    errorMessage = errorMessage,
+                )
+            }
+        } else {
+            val code = extractCodeFrom(callbackUrl)
+            if (code.isNullOrBlank()) {
+                _authState.update {
+                    PKCEAuthState(
+                        PKCEAuthState.State.FINISHED,
+                        errorMessage = "Authorization code missing from external sign in.",
+                    )
+                }
+            } else {
+                _authState.update {
+                    PKCEAuthState(
+                        PKCEAuthState.State.EXCHANGING_AUTHORIZATION_CODE,
+                    )
+                }
+
+                externalScope.launch {
+                    exchangeAuthorizationCode(code)
+                }
+            }
+        }
+    }
+
+    /**
+     * Given a callback URL like `exampleapp://auth?code=1234abcd`, this method
+     * extracts the code query param for use in [exchangeAuthorizationCode]
+     */
+    private fun extractCodeFrom(callbackUrl: String?): String? = try {
+        callbackUrl?.let { Url(it).parameters }?.get("code")
+    } catch (e: URLParserException) {
+        null
+    }
+
+    private suspend fun exchangeAuthorizationCode(code: String) {
+        try {
+            val tokenResponse = withContext(ioDispatcher) {
+                oauthService.exchangeAuthorizationCode(code, verifier!!, redirectUrl)
+            }
+
+            _authState.update {
+                PKCEAuthState(
+                    PKCEAuthState.State.FINISHED,
+                    tokenResponse = tokenResponse,
+                )
+            }
+        } catch (e: Exception) {
+            _authState.update {
+                PKCEAuthState(
+                    PKCEAuthState.State.FINISHED,
+                    errorMessage = e.message,
+                )
+            }
+        }
+    }
+
+    /**
+     * Resets the auth state back to NOT_STARTED. Typically called after encountering
+     * a FINISHED state to clear the token response from memory.
+     */
+    fun resetState() {
+        verifier = null
+
+        _authState.update { PKCEAuthState() }
+    }
+}

--- a/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/PKCEFlow.kt
+++ b/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/PKCEFlow.kt
@@ -6,6 +6,7 @@ import io.ktor.http.Url
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -31,23 +32,23 @@ import kotlin.random.Random
  * @param random This should _always_ be `SecureRandom()`, but we allow constructor injection here in order
  *  to control the randomization values generated under test.
  */
-class PKCEFlow(
+public class PKCEFlow(
     private val platformPKCEFlow: PlatformPKCEFlow,
     private val oauthService: OAuthService,
-    val oauthBaseUrl: String,
-    val redirectUrl: String,
+    private val oauthBaseUrl: String,
+    private val redirectUrl: String,
     private val externalScope: CoroutineScope,
     private val ioDispatcher: CoroutineDispatcher,
     private val random: Random = SecureRandom(),
 ) {
     private val pkce by lazy { PKCEUtil(random) }
 
-    data class PKCEAuthState(
+    public data class PKCEAuthState(
         val state: State = State.NOT_STARTED,
         val tokenResponse: TokenResponse? = null,
         val errorMessage: String? = null,
     ) {
-        enum class State {
+        public enum class State {
             NOT_STARTED,
             WAITING_FOR_AUTHORIZATION_CODE,
             EXCHANGING_AUTHORIZATION_CODE,
@@ -56,7 +57,7 @@ class PKCEFlow(
     }
 
     private val _authState = MutableStateFlow(PKCEAuthState())
-    val authState = _authState.asStateFlow()
+    public val authState: StateFlow<PKCEAuthState> = _authState.asStateFlow()
 
     private var verifier: String? = null
 
@@ -96,7 +97,7 @@ class PKCEFlow(
      * Main entry point for the PKCE Flow. Transfers control of the auth process to the platform,
      * which opens the external browser to the appropriate sign in URL.
      */
-    fun startSignIn() {
+    public fun startSignIn() {
         _authState.update {
             PKCEAuthState(PKCEAuthState.State.WAITING_FOR_AUTHORIZATION_CODE)
         }
@@ -110,7 +111,7 @@ class PKCEFlow(
      * in turn needs to transfer control back here to process the callback URL to swap the
      * authorization code for access/refresh tokens.
      */
-    fun continueSignInWithCallbackOrError(
+    public fun continueSignInWithCallbackOrError(
         callbackUrl: String?,
         errorMessage: String?,
     ) {
@@ -180,7 +181,7 @@ class PKCEFlow(
      * Resets the auth state back to NOT_STARTED. Typically called after encountering
      * a FINISHED state to clear the token response from memory.
      */
-    fun resetState() {
+    public fun resetState() {
         verifier = null
 
         _authState.update { PKCEAuthState() }

--- a/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/PKCEUtil.kt
+++ b/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/PKCEUtil.kt
@@ -1,0 +1,71 @@
+package com.collectiveidea.oauth
+
+import com.chrynan.krypt.csprng.SecureRandom
+import okio.ByteString
+import okio.ByteString.Companion.encodeUtf8
+import okio.ByteString.Companion.toByteString
+import kotlin.random.Random
+
+/**
+ * A utility class with helpers for implementing the Proof Key for Code Exchange (PKCE,
+ * pronounced "pixy").
+ *
+ * Implementation inspired by [krypt-pkce](https://github.com/chRyNaN/krypt/blob/develop/krypt-pkce/src/commonMain/kotlin/com.chrynan.krypt.pkce/Pkce.kt)
+ * but directly leveraging Okio for simplicity.
+ *
+ * @see [RFC-7636](https://datatracker.ietf.org/doc/html/rfc7636)
+ */
+class PKCEUtil(
+    private val random: Random = SecureRandom(),
+) {
+    /**
+     * Extension function for Okio to create URL-Safe Base64 encoding without
+     * trailing padding, required for the PKCE flow.
+     */
+    private fun ByteString.base64UrlNoPadding(): String = base64Url().dropLastWhile { it == '=' }
+
+    /**
+     * Generates a "code_verifier" specified in the PKCE protocol. This value is considered a secure key.
+     *
+     * @see [RFC-7636](https://datatracker.ietf.org/doc/html/rfc7636#section-4.1)
+     */
+    fun generateCodeVerifier(byteLength: Int = 32): String {
+        val bytes = random.nextBytes(byteLength)
+
+        return bytes.toByteString().base64UrlNoPadding()
+    }
+
+    /**
+     * Creates a "code_challenge", specified in the PKCE protocol, from the provided [verifier], using the provided
+     * transformation [method]. If the provided [method] is [CodeChallengeMethod.PLAIN], then the [verifier] is simply
+     * returned, otherwise, if the provided [method] is [CodeChallengeMethod.S256], an SHA-256 hash operation is
+     * performed and the result is returned.
+     *
+     * Note that the code challenge is returned as URL-safe base64, minus trailing `=` padding, per Appendix A.
+     *
+     * @see [RFC-7636](https://datatracker.ietf.org/doc/html/rfc7636#section-4.2)
+     * @see [RFC-7636: Appendix B](https://datatracker.ietf.org/doc/html/rfc7636#appendix-B)
+     */
+    @Suppress("MemberVisibilityCanBePrivate")
+    fun createCodeChallenge(
+        verifier: String,
+        method: CodeChallengeMethod = CodeChallengeMethod.S256,
+    ): String = when (method) {
+        CodeChallengeMethod.PLAIN -> verifier
+        CodeChallengeMethod.S256 -> verifier.encodeUtf8().sha256().base64UrlNoPadding()
+    }
+
+    /**
+     * Represents the supported transformation methods in the PKCE protocol. Currently, the only supported methods are
+     * [PLAIN] and [S256]. The [PLAIN] method performs no operation, while the [S256] performs an SHA-256 hash.
+     *
+     * Implementation inspired by [krypt-pkce](https://github.com/chRyNaN/krypt/blob/develop/krypt-pkce/src/commonMain/kotlin/com.chrynan.krypt.pkce/CodeChallengeMethod.kt)
+     * but modified for simplicity.
+     */
+    enum class CodeChallengeMethod(
+        val typeName: String,
+    ) {
+        PLAIN(typeName = "plain"),
+        S256(typeName = "S256"),
+    }
+}

--- a/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/PKCEUtil.kt
+++ b/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/PKCEUtil.kt
@@ -15,7 +15,7 @@ import kotlin.random.Random
  *
  * @see [RFC-7636](https://datatracker.ietf.org/doc/html/rfc7636)
  */
-class PKCEUtil(
+internal class PKCEUtil(
     private val random: Random = SecureRandom(),
 ) {
     /**

--- a/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/PlatformPKCEFlow.kt
+++ b/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/PlatformPKCEFlow.kt
@@ -1,0 +1,26 @@
+package com.collectiveidea.oauth
+
+interface PlatformPKCEFlow {
+    /**
+     * Starts the PKCE OAuth flow in a platform-native external browser session.
+     *
+     * For [com.collectiveidea.oauth.AndroidPKCEFlow], this is done via Custom Tabs.
+     * For [com.collectiveidea.oauth.IosPKCEFlow], this is done via AuthenticationServices.
+     *
+     * @param signInUrl The result of a call to [PKCEFlow.buildSignInUrl]
+     * @param redirectUrl The app scheme oauth link that the external browser should redirect the
+     *  user to after successful authorization (to transfer control back to the app), e.g. "exampleapp://oauth".
+     *  The server will append a "?code=example_auth_code" to this Url for the app to process.
+     * @param completionHandler A reference to the [PKCEFlow.continueSignInWithCallbackOrError] method.
+     *  When supported by the platform (e.g. iOS), the sign in process may directly invoke this completion
+     *  handler with the callbackUrl, without the app having to transfer control back to the [PKCEFlow] explicitly.
+     *
+     *  Android will not invoke the completionHandler; It must be called in `onNewIntent` once
+     *  the platform transfer control back to the app Activity via the redirectUrl.
+     */
+    fun startSignIn(
+        signInUrl: String,
+        redirectUrl: String,
+        completionHandler: (String?, String?) -> Unit,
+    )
+}

--- a/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/PlatformPKCEFlow.kt
+++ b/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/PlatformPKCEFlow.kt
@@ -1,6 +1,6 @@
 package com.collectiveidea.oauth
 
-interface PlatformPKCEFlow {
+public interface PlatformPKCEFlow {
     /**
      * Starts the PKCE OAuth flow in a platform-native external browser session.
      *
@@ -18,7 +18,7 @@ interface PlatformPKCEFlow {
      *  Android will not invoke the completionHandler; It must be called in `onNewIntent` once
      *  the platform transfer control back to the app Activity via the redirectUrl.
      */
-    fun startSignIn(
+    public fun startSignIn(
         signInUrl: String,
         redirectUrl: String,
         completionHandler: (String?, String?) -> Unit,

--- a/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/RefreshTokensRequest.kt
+++ b/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/RefreshTokensRequest.kt
@@ -1,0 +1,11 @@
+package com.collectiveidea.oauth
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+class RefreshTokensRequest(
+    @SerialName("client_id") val clientId: String,
+    @SerialName("grant_type") val grantType: String = "refresh_token",
+    @SerialName("refresh_token") val refreshToken: String,
+)

--- a/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/RefreshTokensRequest.kt
+++ b/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/RefreshTokensRequest.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-class RefreshTokensRequest(
+public data class RefreshTokensRequest(
     @SerialName("client_id") val clientId: String,
     @SerialName("grant_type") val grantType: String = "refresh_token",
     @SerialName("refresh_token") val refreshToken: String,

--- a/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/TokenResponse.kt
+++ b/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/TokenResponse.kt
@@ -1,0 +1,14 @@
+package com.collectiveidea.oauth
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TokenResponse(
+    @SerialName("access_token") val accessToken: String,
+    @SerialName("token_type") val tokenType: String,
+    @SerialName("expires_in") val expiresIn: Int,
+    @SerialName("refresh_token") val refreshToken: String? = null,
+    @SerialName("created_at") val createdAt: Int,
+    @SerialName("scope") val scope: String? = null,
+)

--- a/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/TokenResponse.kt
+++ b/oauth-core/src/commonMain/kotlin/com/collectiveidea/oauth/TokenResponse.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class TokenResponse(
+public data class TokenResponse(
     @SerialName("access_token") val accessToken: String,
     @SerialName("token_type") val tokenType: String,
     @SerialName("expires_in") val expiresIn: Int,

--- a/oauth-core/src/commonTest/kotlin/com/collectiveidea/oauth/OAuthServiceTest.kt
+++ b/oauth-core/src/commonTest/kotlin/com/collectiveidea/oauth/OAuthServiceTest.kt
@@ -1,0 +1,94 @@
+package com.collectiveidea.oauth
+
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.content.TextContent
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+val jsonDecoder = Json
+
+class OAuthServiceTest {
+    @Test
+    fun `exchangeAuthorizationCode success`() = runTest {
+        val mockEngine = MockEngine {
+            assertEquals("https://localhost/oauth/token", it.url.toString())
+
+            // Validate body request contains the correct information
+            val request = jsonDecoder.decodeFromString<AuthorizationCodeRequest>((it.body as TextContent).text)
+            assertEquals("example_client_id", request.clientId)
+            assertEquals("example_code", request.code)
+            assertEquals("example_verifier", request.verifier)
+            assertEquals("authorization_code", request.grantType)
+            assertEquals("exampleapp://auth", request.redirectUrl)
+
+            respondWithOAuthTokens(true)
+        }
+        val oAuthService = createOAuthService(mockEngine)
+
+        val response = oAuthService.exchangeAuthorizationCode("example_code", "example_verifier", "exampleapp://auth")
+
+        assertEquals("access_token_value", response.accessToken)
+        assertEquals("refresh_token_value", response.refreshToken)
+        assertEquals("Bearer", response.tokenType)
+        assertEquals(7200, response.expiresIn)
+        assertEquals(1661450918, response.createdAt)
+        assertEquals("public write", response.scope)
+    }
+
+    @Test
+    fun `exchangeAuthorizationCode invalid`() = runTest {
+        val oAuthService = createOAuthService(MockEngine { respondWithOAuthError() })
+
+        val exception = assertFailsWith<OAuthException> {
+            oAuthService.exchangeAuthorizationCode("example_code", "fake_verifier", "exampleapp://auth")
+        }
+        val expectedError = OAuthError(
+            "invalid_grant",
+            "The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.",
+        )
+        assertEquals(expectedError, exception.error)
+    }
+
+    @Test
+    fun `refreshTokens success`() = runTest {
+        val mockEngine = MockEngine {
+            assertEquals("https://localhost/oauth/token", it.url.toString())
+
+            // Validate body request contains the correct information
+            val request = jsonDecoder.decodeFromString<RefreshTokensRequest>((it.body as TextContent).text)
+            assertEquals("the_valid_request_token", request.refreshToken)
+            assertEquals("example_client_id", request.clientId)
+            assertEquals("refresh_token", request.grantType)
+
+            respondWithOAuthTokens()
+        }
+        val oAuthService = createOAuthService(mockEngine)
+
+        val response = oAuthService.refreshTokens("the_valid_request_token")
+
+        assertEquals("access_token_value", response.accessToken)
+        assertEquals("refresh_token_value", response.refreshToken)
+        assertEquals("Bearer", response.tokenType)
+        assertEquals(7200, response.expiresIn)
+        assertEquals(1661450918, response.createdAt)
+        assertNull(response.scope)
+    }
+
+    @Test
+    fun `refreshTokens invalid`() = runTest {
+        val oAuthService = createOAuthService(MockEngine { respondWithOAuthError() })
+
+        val exception = assertFailsWith<OAuthException> {
+            oAuthService.refreshTokens("invalid_refresh_token")
+        }
+        val expectedError = OAuthError(
+            "invalid_grant",
+            "The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.",
+        )
+        assertEquals(expectedError, exception.error)
+    }
+}

--- a/oauth-core/src/commonTest/kotlin/com/collectiveidea/oauth/OAuthServiceTest.kt
+++ b/oauth-core/src/commonTest/kotlin/com/collectiveidea/oauth/OAuthServiceTest.kt
@@ -9,9 +9,9 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 
-val jsonDecoder = Json
-
 class OAuthServiceTest {
+    private val jsonDecoder = Json
+
     @Test
     fun `exchangeAuthorizationCode success`() = runTest {
         val mockEngine = MockEngine {

--- a/oauth-core/src/commonTest/kotlin/com/collectiveidea/oauth/PKCEFlowTest.kt
+++ b/oauth-core/src/commonTest/kotlin/com/collectiveidea/oauth/PKCEFlowTest.kt
@@ -1,0 +1,386 @@
+package com.collectiveidea.oauth
+
+import app.cash.turbine.turbineScope
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.http.Url
+import io.ktor.utils.io.errors.IOException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+class PKCEFlowTest {
+    @Test
+    fun `buildSignInUrl returns correct URL`() {
+        val pkceFlow = PKCEFlow(
+            TestPlatformPKCEFlow(),
+            createOAuthService(
+                MockEngine {
+                    fail("should not be invoked")
+                },
+            ),
+            oauthBaseUrl = "https://www.example.com/path/",
+            redirectUrl = "exampleapp://oauth",
+            MainScope(),
+            Dispatchers.IO,
+            // We use a known Random seed of 1234 to always get the same code challenge under test
+            random = Random(1234),
+        )
+
+        val url = Url(pkceFlow.buildSignInUrl())
+
+        assertEquals("www.example.com", url.host)
+        assertEquals("/path/oauth/authorize", url.encodedPath)
+
+        val parameters = url.parameters
+
+        assertEquals("example_client_id", parameters["client_id"])
+        // TRICKY: parameters.get will URL-decode `exampleapp%3A%2F%2Fauth`
+        assertEquals("exampleapp://oauth", parameters["redirect_uri"])
+        // TRICKY: parameters.get will URL-decode `public+write`
+        assertEquals("public write", parameters["scope"])
+        assertEquals("XFZKmPQOu1pBFhonCwSRnksNVNGsSigoVZObIQa1ngU", parameters["code_challenge"])
+        assertEquals("S256", parameters["code_challenge_method"])
+    }
+
+    @Test
+    fun `flow happy path completes successfully`() = runTest {
+        val pkceFlow = PKCEFlow(
+            TestPlatformPKCEFlow(
+                automaticallyInvokeCompletionCallback = true,
+            ),
+            createOAuthService(
+                MockEngine {
+                    respondWithOAuthTokens()
+                },
+            ),
+            oauthBaseUrl = "https://www.example.com/path/",
+            redirectUrl = "exampleapp://oauth",
+            externalScope = CoroutineScope(StandardTestDispatcher(testScheduler)),
+            ioDispatcher = Dispatchers.IO,
+        )
+
+        turbineScope {
+            val turbine = pkceFlow.authState.testIn(backgroundScope)
+
+            // Initial state
+
+            assertEquals(
+                PKCEFlow.PKCEAuthState(
+                    state = PKCEFlow.PKCEAuthState.State.NOT_STARTED,
+                ),
+                turbine.awaitItem(),
+            )
+
+            // Start the sign-in process
+
+            pkceFlow.startSignIn()
+
+            assertEquals(
+                PKCEFlow.PKCEAuthState(
+                    state = PKCEFlow.PKCEAuthState.State.WAITING_FOR_AUTHORIZATION_CODE,
+                ),
+                turbine.awaitItem(),
+            )
+
+            // In this scenario the sign in completion callback is automatically invoked
+            // with a valid callback url containing an authorization code.
+
+            assertEquals(
+                PKCEFlow.PKCEAuthState(
+                    state = PKCEFlow.PKCEAuthState.State.EXCHANGING_AUTHORIZATION_CODE,
+                ),
+                turbine.awaitItem(),
+            )
+
+            assertEquals(
+                PKCEFlow.PKCEAuthState(
+                    state = PKCEFlow.PKCEAuthState.State.FINISHED,
+                    tokenResponse = TokenResponse(
+                        accessToken = "access_token_value",
+                        tokenType = "Bearer",
+                        expiresIn = 7200,
+                        refreshToken = "refresh_token_value",
+                        createdAt = 1661450918,
+                        scope = null,
+                    ),
+                    errorMessage = null,
+                ),
+                turbine.awaitItem(),
+            )
+
+            // Clear the token response from memory now that we've examined it.
+
+            pkceFlow.resetState()
+
+            assertEquals(
+                PKCEFlow.PKCEAuthState(
+                    state = PKCEFlow.PKCEAuthState.State.NOT_STARTED,
+                ),
+                turbine.awaitItem(),
+            )
+
+            turbine.ensureAllEventsConsumed()
+        }
+    }
+
+    @Test
+    fun `flow happy path completes successfully when manually invoking completion callback`() = runTest {
+        val pkceFlow = PKCEFlow(
+            TestPlatformPKCEFlow(
+                automaticallyInvokeCompletionCallback = false,
+            ),
+            createOAuthService(
+                MockEngine {
+                    respondWithOAuthTokens()
+                },
+            ),
+            oauthBaseUrl = "https://www.example.com/path/",
+            redirectUrl = "exampleapp://oauth",
+            externalScope = CoroutineScope(StandardTestDispatcher(testScheduler)),
+            ioDispatcher = Dispatchers.IO,
+        )
+
+        turbineScope {
+            val turbine = pkceFlow.authState.testIn(backgroundScope)
+
+            // Initial state
+
+            assertEquals(
+                PKCEFlow.PKCEAuthState(
+                    state = PKCEFlow.PKCEAuthState.State.NOT_STARTED,
+                ),
+                turbine.awaitItem(),
+            )
+
+            // Start the sign-in process
+
+            pkceFlow.startSignIn()
+
+            assertEquals(
+                PKCEFlow.PKCEAuthState(
+                    state = PKCEFlow.PKCEAuthState.State.WAITING_FOR_AUTHORIZATION_CODE,
+                ),
+                turbine.awaitItem(),
+            )
+
+            // In this scenario the sign in completion callback must be manually invoked
+
+            pkceFlow.continueSignInWithCallbackOrError("exampleapp://oauth?code=fake-code", null)
+
+            assertEquals(
+                PKCEFlow.PKCEAuthState(
+                    state = PKCEFlow.PKCEAuthState.State.EXCHANGING_AUTHORIZATION_CODE,
+                ),
+                turbine.awaitItem(),
+            )
+
+            assertEquals(
+                PKCEFlow.PKCEAuthState(
+                    state = PKCEFlow.PKCEAuthState.State.FINISHED,
+                    tokenResponse = TokenResponse(
+                        accessToken = "access_token_value",
+                        tokenType = "Bearer",
+                        expiresIn = 7200,
+                        refreshToken = "refresh_token_value",
+                        createdAt = 1661450918,
+                        scope = null,
+                    ),
+                    errorMessage = null,
+                ),
+                turbine.awaitItem(),
+            )
+
+            turbine.ensureAllEventsConsumed()
+        }
+    }
+
+    @Test
+    fun `flow reports error message when platform invoke callback with error message`() = runTest {
+        val pkceFlow = PKCEFlow(
+            TestPlatformPKCEFlow(
+                automaticallyInvokeCompletionCallback = true,
+                simulateError = true,
+            ),
+            createOAuthService(
+                MockEngine {
+                    fail("should not be invoked")
+                },
+            ),
+            oauthBaseUrl = "https://www.example.com/path/",
+            redirectUrl = "exampleapp://oauth",
+            externalScope = CoroutineScope(StandardTestDispatcher(testScheduler)),
+            ioDispatcher = Dispatchers.IO,
+        )
+
+        turbineScope {
+            val turbine = pkceFlow.authState.testIn(backgroundScope)
+
+            // Initial state
+
+            assertEquals(
+                PKCEFlow.PKCEAuthState(
+                    state = PKCEFlow.PKCEAuthState.State.NOT_STARTED,
+                ),
+                turbine.awaitItem(),
+            )
+
+            // Start the sign-in process
+
+            pkceFlow.startSignIn()
+
+            assertEquals(
+                PKCEFlow.PKCEAuthState(
+                    state = PKCEFlow.PKCEAuthState.State.WAITING_FOR_AUTHORIZATION_CODE,
+                ),
+                turbine.awaitItem(),
+            )
+
+            // In this scenario the sign in completion callback is automatically invoked
+            // and an error message is supplied by the platform instead of a valid code.
+
+            assertEquals(
+                PKCEFlow.PKCEAuthState(
+                    state = PKCEFlow.PKCEAuthState.State.FINISHED,
+                    tokenResponse = null,
+                    errorMessage = "Simulated External Authorization Error",
+                ),
+                turbine.awaitItem(),
+            )
+
+            turbine.ensureAllEventsConsumed()
+        }
+    }
+
+    @Test
+    fun `flow reports error message when server rejects authorization code`() = runTest {
+        val pkceFlow = PKCEFlow(
+            TestPlatformPKCEFlow(
+                automaticallyInvokeCompletionCallback = true
+            ),
+            createOAuthService(
+                MockEngine {
+                    respondWithOAuthError()
+                },
+            ),
+            oauthBaseUrl = "https://www.example.com/path/",
+            redirectUrl = "exampleapp://oauth",
+            externalScope = CoroutineScope(StandardTestDispatcher(testScheduler)),
+            ioDispatcher = Dispatchers.IO,
+        )
+
+        turbineScope {
+            val turbine = pkceFlow.authState.testIn(backgroundScope)
+
+            // Initial state
+
+            assertEquals(
+                PKCEFlow.PKCEAuthState(
+                    state = PKCEFlow.PKCEAuthState.State.NOT_STARTED,
+                ),
+                turbine.awaitItem(),
+            )
+
+            // Start the sign-in process
+
+            pkceFlow.startSignIn()
+
+            assertEquals(
+                PKCEFlow.PKCEAuthState(
+                    state = PKCEFlow.PKCEAuthState.State.WAITING_FOR_AUTHORIZATION_CODE,
+                ),
+                turbine.awaitItem(),
+            )
+
+            // In this scenario the sign in completion callback is automatically invoked
+            // with an authorization code, but the code exchange fails.
+
+            assertEquals(
+                PKCEFlow.PKCEAuthState(
+                    state = PKCEFlow.PKCEAuthState.State.EXCHANGING_AUTHORIZATION_CODE,
+                ),
+                turbine.awaitItem(),
+            )
+
+            assertEquals(
+                PKCEFlow.PKCEAuthState(
+                    state = PKCEFlow.PKCEAuthState.State.FINISHED,
+                    tokenResponse = null,
+                    errorMessage = "The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.",
+                ),
+                turbine.awaitItem(),
+            )
+
+            turbine.ensureAllEventsConsumed()
+        }
+    }
+
+    @Test
+    fun `flow reports error message when authorization code fails`() = runTest {
+        val pkceFlow = PKCEFlow(
+            TestPlatformPKCEFlow(
+                automaticallyInvokeCompletionCallback = true
+            ),
+            createOAuthService(
+                MockEngine {
+                    throw IOException("Simulated Network Error")
+                },
+            ),
+            oauthBaseUrl = "https://www.example.com/path/",
+            redirectUrl = "exampleapp://oauth",
+            externalScope = CoroutineScope(StandardTestDispatcher(testScheduler)),
+            ioDispatcher = Dispatchers.IO,
+        )
+
+        turbineScope {
+            val turbine = pkceFlow.authState.testIn(backgroundScope)
+
+            // Initial state
+
+            assertEquals(
+                PKCEFlow.PKCEAuthState(
+                    state = PKCEFlow.PKCEAuthState.State.NOT_STARTED,
+                ),
+                turbine.awaitItem(),
+            )
+
+            // Start the sign-in process
+
+            pkceFlow.startSignIn()
+
+            assertEquals(
+                PKCEFlow.PKCEAuthState(
+                    state = PKCEFlow.PKCEAuthState.State.WAITING_FOR_AUTHORIZATION_CODE,
+                ),
+                turbine.awaitItem(),
+            )
+
+            // In this scenario the sign in completion callback is automatically invoked
+            // with an authorization code, but the code exchange fails.
+
+            assertEquals(
+                PKCEFlow.PKCEAuthState(
+                    state = PKCEFlow.PKCEAuthState.State.EXCHANGING_AUTHORIZATION_CODE,
+                ),
+                turbine.awaitItem(),
+            )
+
+            assertEquals(
+                PKCEFlow.PKCEAuthState(
+                    state = PKCEFlow.PKCEAuthState.State.FINISHED,
+                    tokenResponse = null,
+                    errorMessage = "Simulated Network Error",
+                ),
+                turbine.awaitItem(),
+            )
+
+            turbine.ensureAllEventsConsumed()
+        }
+    }
+}

--- a/oauth-core/src/commonTest/kotlin/com/collectiveidea/oauth/TestHelpers.kt
+++ b/oauth-core/src/commonTest/kotlin/com/collectiveidea/oauth/TestHelpers.kt
@@ -1,0 +1,74 @@
+package com.collectiveidea.oauth
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.mock.MockRequestHandleScope
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.HttpResponseData
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.http.withCharset
+import io.ktor.utils.io.charsets.Charsets
+
+class TestPlatformPKCEFlow(
+    val automaticallyInvokeCompletionCallback: Boolean = false,
+    val simulateError: Boolean = false,
+) : PlatformPKCEFlow {
+    override fun startSignIn(
+        signInUrl: String,
+        redirectUrl: String,
+        completionHandler: (String?, String?) -> Unit,
+    ) {
+        if (automaticallyInvokeCompletionCallback) {
+            if (simulateError) {
+                completionHandler(null, "Simulated External Authorization Error")
+            } else {
+                completionHandler("$redirectUrl?code=the-auth-code", null)
+            }
+        }
+    }
+}
+
+private fun createOAuthHttpClient(engine: HttpClientEngine) = HttpClient(engine) {
+    installJsonOAuth("https://localhost/")
+}
+
+fun createOAuthService(engine: HttpClientEngine): OAuthService = OAuthServiceImpl(
+    createOAuthHttpClient(engine),
+    "example_client_id",
+)
+
+fun MockRequestHandleScope.respondWithOAuthTokens(includeScope: Boolean = false): HttpResponseData {
+    val scope: String = if (includeScope) ",\"scope\":\"public write\"" else ""
+    return respond(
+        """
+        {
+            "access_token":"access_token_value",
+            "token_type":"Bearer",
+            "expires_in":7200,
+            "refresh_token":"refresh_token_value",
+            "created_at":1661450918$scope
+        }
+        """.trimIndent(),
+        HttpStatusCode.OK,
+        headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+    )
+}
+
+fun MockRequestHandleScope.respondWithOAuthError(): HttpResponseData = respond(
+    """
+        {
+            "error":"invalid_grant",
+            "error_description":"The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client."
+        }
+    """.trimIndent(),
+    HttpStatusCode.BadRequest,
+    headersOf(
+        HttpHeaders.ContentType,
+        ContentType.Application.Json
+            .withCharset(Charsets.UTF_8)
+            .toString(),
+    ),
+)

--- a/oauth-core/src/iosMain/kotlin/com/collectiveidea/oauth/IosPKCEFlow.kt
+++ b/oauth-core/src/iosMain/kotlin/com/collectiveidea/oauth/IosPKCEFlow.kt
@@ -9,7 +9,7 @@ import platform.Foundation.NSURL
 import platform.UIKit.UIApplication
 import platform.darwin.NSObject
 
-class IosPKCEFlow: PlatformPKCEFlow {
+public class IosPKCEFlow: PlatformPKCEFlow {
     override fun startSignIn(signInUrl: String, redirectUrl: String, completionHandler: (String?, String?) -> Unit) {
         val authSession = ASWebAuthenticationSession(
             uRL = NSURL.URLWithString(signInUrl)!!,

--- a/oauth-core/src/iosMain/kotlin/com/collectiveidea/oauth/IosPKCEFlow.kt
+++ b/oauth-core/src/iosMain/kotlin/com/collectiveidea/oauth/IosPKCEFlow.kt
@@ -1,0 +1,39 @@
+package com.collectiveidea.oauth
+
+import platform.AuthenticationServices.ASPresentationAnchor
+import platform.AuthenticationServices.ASWebAuthenticationPresentationContextProvidingProtocol
+import platform.AuthenticationServices.ASWebAuthenticationSession
+import platform.AuthenticationServices.ASWebAuthenticationSessionCompletionHandler
+import platform.Foundation.NSError
+import platform.Foundation.NSURL
+import platform.UIKit.UIApplication
+import platform.darwin.NSObject
+
+class IosPKCEFlow: PlatformPKCEFlow {
+    override fun startSignIn(signInUrl: String, redirectUrl: String, completionHandler: (String?, String?) -> Unit) {
+        val authSession = ASWebAuthenticationSession(
+            uRL = NSURL.URLWithString(signInUrl)!!,
+            callbackURLScheme = NSURL.URLWithString(redirectUrl)!!.scheme,
+            completionHandler = object : ASWebAuthenticationSessionCompletionHandler {
+                override fun invoke(callbackUrl: NSURL?, error: NSError?) {
+                    completionHandler(
+                        callbackUrl?.absoluteString,
+                        error?.localizedDescription
+                    )
+                }
+            }
+        )
+
+        authSession.presentationContextProvider = object : NSObject(), ASWebAuthenticationPresentationContextProvidingProtocol {
+            // https://developer.apple.com/documentation/authenticationservices/aswebauthenticationpresentationcontextproviding/presentationanchor(for:)?language=objc
+            override fun presentationAnchorForWebAuthenticationSession(session: ASWebAuthenticationSession): ASPresentationAnchor {
+                return UIApplication.sharedApplication.keyWindow ?: ASPresentationAnchor()
+            }
+        }
+
+        authSession.prefersEphemeralWebBrowserSession = true
+        authSession.start()
+    }
+
+
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,9 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+
+        // For krypt SecureRandom
+        maven { url = uri("https://repo.repsy.io/mvn/chrynan/public") }
     }
 }
 


### PR DESCRIPTION
Extracts the OAuth PKCE Flow library code from our internal reference project.

Enables Kotlin Explicit API mode for library authors. See https://kotlinlang.org/docs/reference/whatsnew14.html#explicit-api-mode-for-library-authors and https://kotlinlang.org/docs/api-guidelines-simplicity.html#use-explicit-api-mode