### PR TITLE
Update publishing

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,4 +27,12 @@
    $ ./gradlew publish
    ```
 
-6. Visit [Sonatype Nexus](https://s01.oss.sonatype.org) and promote the artifact. (Close the staging repository, then Release it)
+6. Promote from Staging
+
+   ```
+   source ~/.gradle/gradle.properties
+   repository_key=$(curl -u $SONATYPE_USERNAME:$SONATYPE_PASSWORD -X GET "https://ossrh-staging-api.central.sonatype.com/manual/search/repositories?ip=any&profile_id=com.collectiveidea" | jq --raw-output ".repositories[0].key")
+   curl -u $SONATYPE_USERNAME:$SONATYPE_PASSWORD -X POST "https://ossrh-staging-api.central.sonatype.com/manual/upload/repository/$repository_key"
+   ```
+
+7. Visit https://central.sonatype.com/publishing/deployments and press Publish

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,8 +29,8 @@ if (sonatypeUsername != null) {
                 repositories {
                     maven {
                         name = "oss"
-                        val releasesRepoUrl = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
-                        val snapshotsRepoUrl = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+                        val releasesRepoUrl = uri("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/")
+                        val snapshotsRepoUrl = uri("https://central.sonatype.com/repository/maven-snapshots/")
                         url = if (version.toString().endsWith("-SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl
 
                         credentials {


### PR DESCRIPTION
Update publish URLs per https://central.sonatype.org/news/20250326_ossrh_sunset/ 

Update my RELEASING documentation for publishing instructions per https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuring-the-repository and https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#2-make-separate-requests

This is a bit of a stop-gap. We should really have GitHub Actions auto-publish when we push a new version tag.